### PR TITLE
changed spectra scaling

### DIFF
--- a/peakTree/__init__.py
+++ b/peakTree/__init__.py
@@ -403,11 +403,13 @@ class peakTreeBuffer():
         self.begin_dt = h.ts_to_dt(self.timestamps[0])
 
         scaling = self.settings['tot_spec_scaling']
-        log.warning(f"WARNING: the scaling factor is hard-coded, rpg software version > 5.40, configured are {scaling}")
+        log.warning(f"WARNING: Taking scaling factor from config file. It should be 1 for RPG software version > 5.40, "
+                    f"and 0.5 for earlier software versions (around 2020). Only applicable for STSR radar. Configured "
+                    f"are {scaling}")
 
         if load_to_ram == True:
             self.spectra_in_ram = True
-            self.doppler_spectrum, spec_mask = h.masked_to_plain(self.f.variables['doppler_spectrum'][:])
+            self.doppler_spectrum, spec_mask = h.masked_to_plain(scaling*self.f.variables['doppler_spectrum'][:])
             self.doppler_spectrum_h, spec_h_mask = h.masked_to_plain(self.f.variables['doppler_spectrum_h'][:])
             self.covariance_spectrum_re, cov_re_mask = h.masked_to_plain(self.f.variables['covariance_spectrum_re'][:])
             self.covariance_spectrum_im, cov_im_mask = h.masked_to_plain(self.f.variables['covariance_spectrum_im'][:])
@@ -416,7 +418,7 @@ class peakTreeBuffer():
             self.integrated_noise, _ = h.masked_to_plain(self.f.variables['integrated_noise'][:])
             self.integrated_noise_h, _ = h.masked_to_plain(self.f.variables['integrated_noise_h'][:])
 
-            self.doppler_spectrum_v = scaling*self.doppler_spectrum - self.doppler_spectrum_h - 2 * self.covariance_spectrum_re
+            self.doppler_spectrum_v = 4 * self.doppler_spectrum - self.doppler_spectrum_h - 2 * self.covariance_spectrum_re
             noise_v = self.integrated_noise / 2.
 
 


### PR DESCRIPTION
RPG radar: changed the scaling of spectra from 2 and 4 to 0.5 and 1, respectively and adjusted the computation of the v-channel spectrum accordingly 