### PR TITLE
a few minor changes

### DIFF
--- a/peakTree/__init__.py
+++ b/peakTree/__init__.py
@@ -471,10 +471,15 @@ class peakTreeBuffer():
 
                 # updated noise
                 self.navg = (2*header['ChirpFFTSize']*header['ChirpReps'])/(header['SpecN'])-1
-                self.noise_lvl = (data['TotNoisePow']+data['HNoisePow'])/\
+                self.noise_lvl = self.integrated_noise/\
                             (2*np.repeat(self.n_samples_in_chirp, bins_per_chirp))
-                self.noise_tot = data['TotNoisePow']/np.repeat(self.n_samples_in_chirp, bins_per_chirp)
-                self.noise_h = data['HNoisePow']/np.repeat(self.n_samples_in_chirp, bins_per_chirp)
+                if 'TotNoisePow' in data:
+                    self.noise_h = data['HNoisePow']/np.repeat(self.n_samples_in_chirp, bins_per_chirp)
+                    self.noise_tot = data['TotNoisePow']/np.repeat(self.n_samples_in_chirp, bins_per_chirp)
+                else:
+                    # option for spectra files for which no noise power variable is saved - untested!
+                    self.noise_h = h.estimate_noise_array(self.doppler_spectrum_h)
+                    self.noise_tot = self.noise_lvl - self.noise_h
                 Q = 6
                 self.noise_thres = Q*self.noise_lvl/np.repeat(np.sqrt(self.navg), bins_per_chirp)
 

--- a/peakTree/__init__.py
+++ b/peakTree/__init__.py
@@ -1412,7 +1412,7 @@ class peakTreeBuffer():
 
             travtree = {}
             #travtree = generate_tree.tree_from_spectrum({**spectrum}, peak_finding_params)
-            travtree = generate_tree.tree_from_spectrum_peako({**spectrum}, peak_finding_params)
+            travtree = generate_tree.tree_from_spectrum_peako({**spectrum}, peak_finding_params, gaps=gaps)
 
             return travtree, spectrum
 

--- a/peakTree/__init__.py
+++ b/peakTree/__init__.py
@@ -1336,7 +1336,7 @@ class peakTreeBuffer():
             # smoothing and cutting. the order can be defined in instrument_config
             if self.settings['smooth_cut_sequence'] == 'cs':
                 specZ[specZ < noise_thres] = np.nan #noise_thres / 6. 
-            if peak_finding_params['smooth_polyorder'] != 0:
+            if peak_finding_params['smooth_polyorder'] != 0 and window_length > 1:
                 specZ = scipy.signal.savgol_filter(specZ, window_length, 
                             polyorder=peak_finding_params['smooth_polyorder'], mode='nearest')
             gaps = (specZ <= 0.) | ~np.isfinite(specZ)

--- a/peakTree/generate_tree.py
+++ b/peakTree/generate_tree.py
@@ -695,6 +695,18 @@ def bounds_from_find_peak(peaks, prop):
 
     return bounds
 
+
+def remove_gap_peaks(locs, props, gaps):
+    """remove peaks detected where gaps were filled with raw spectrum values
+    """
+    index = [i for i in range(len(locs)) if not locs[i] in gaps]
+    locs = locs[index]
+    props_out = {}
+    for key, val in props.items():
+        props_out[key] = val[index]
+    return locs, props_out
+
+
 def fix_peaks_unique(peaks, prop):
     """equally high peaks are not prominence filtered by find_peaks
     (actually specified behavior)
@@ -720,7 +732,7 @@ def fix_peaks_unique(peaks, prop):
     return peaks, prop
 
 
-def tree_from_spectrum_peako(spectrum, peak_finding_params):
+def tree_from_spectrum_peako(spectrum, peak_finding_params, gaps=None):
     """generate the tree and return a traversed version use peako-like peakfinder
 
     Args:
@@ -743,6 +755,8 @@ def tree_from_spectrum_peako(spectrum, peak_finding_params):
         prominence=peak_finding_params['prom_thres'],
         width=width,
         rel_height=0.5)
+    if gaps is not None:
+        locs, props = remove_gap_peaks(locs, props, np.where(gaps)[0])
     log.debug(f'find_peaks locs {locs} props {props}')
     #noise_floor_edges = detect_peak_simple(masked_Z_pf, spectrum['noise_thres'])
     #print('noise_floor_edges', noise_floor_edges)


### PR DESCRIPTION
- passing the "gaps" variable to generate_tree.tree_from_spectrum_peako and not allowing peak detection where there are gaps which were filled with raw spectrum
- if the defined smoothing span would lead to window length = 1, no smoothing is attempted
- option for computation of total noise power, h noise power if these variables are not saved in the lv0 files (experimental)
- round to odd function
- simplified estimate_noise (only mean noise output is needed) 